### PR TITLE
max retry limit fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# IDEA/WebStorm
+/.idea/

--- a/README.md
+++ b/README.md
@@ -77,13 +77,3 @@ if err != nil {
   log.Fatalln("error:", err)
 }
 ```
-
-#### Maximum retry limit
-
-To avoid infinite loops, Try will ensure it only makes `try.MaxRetries` attempts. By default, this value is `10`, but you can change it:
-
-```
-try.MaxRetries = 20
-```
-
-To see if a `Do` operation failed due to reaching the limit, you can check the `error` with `try.IsMaxRetries(err)`.

--- a/try.go
+++ b/try.go
@@ -1,11 +1,9 @@
 package try
 
-import "errors"
-
-// MaxRetries is the maximum number of retries before bailing.
-var MaxRetries = 10
-
-var errMaxRetriesReached = errors.New("exceeded retry limit")
+import (
+	"errors"
+	"fmt"
+)
 
 // Func represents functions that can be retried.
 type Func func(attempt int) (retry bool, err error)
@@ -14,23 +12,17 @@ type Func func(attempt int) (retry bool, err error)
 // returns false, or no error is returned.
 func Do(fn Func) error {
 	var err error
-	var cont bool
+	var retry bool
 	attempt := 1
 	for {
-		cont, err = fn(attempt)
-		if !cont || err == nil {
+		retry, err = fn(attempt)
+		if err == nil {
 			break
 		}
 		attempt++
-		if attempt > MaxRetries {
-			return errMaxRetriesReached
+		if !retry {
+			return errors.New(fmt.Sprintf("exceeded retry limit - %v", err))
 		}
 	}
 	return err
-}
-
-// IsMaxRetries checks whether the error is due to hitting the
-// maximum number of retries or not.
-func IsMaxRetries(err error) bool {
-	return err == errMaxRetriesReached
 }


### PR DESCRIPTION
There was two places with max retry limit logic :
1) variable try.MaxRetries 
2) callback  fn(attempt) return value (cont)

Second only worked if attempt number was less than MaxRetries number, though error message didn't say that max retry limit reached. To change number of max retries you should mutate internal library variable which is not good practice. So I deleted logic with variable try.MaxRetries and fixed logic with callback return value.

Also exceeded MaxRetriesReached error is a little bit more informative.

In conclusion having two places where you should change max limit number is bug prone.